### PR TITLE
Use CNG SHA1 signing

### DIFF
--- a/ITfoxtec.Saml2/Cryptography/Saml2SignedXml.cs
+++ b/ITfoxtec.Saml2/Cryptography/Saml2SignedXml.cs
@@ -27,6 +27,7 @@ namespace ITfoxtec.Saml2.Cryptography
 
         private void AddAlgorithm()
         {
+            CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA1SignatureDescription), SecurityAlgorithms.RsaSha1Signature);
             if (CryptoConfig.CreateFromName(SecurityAlgorithms.RsaSha256Signature) == null)
             {
                 CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA256SignatureDescription), SecurityAlgorithms.RsaSha256Signature);


### PR DESCRIPTION
Now your existing signature formatter is added to `CryptoConfig` in order to replace pre-CNG implementation.
